### PR TITLE
Updates for 0.3.11

### DIFF
--- a/oreum_core/__init__.py
+++ b/oreum_core/__init__.py
@@ -1,2 +1,2 @@
 # copyright 2022 Oreum Industries
-__version__ = "0.3.10"
+__version__ = "0.3.11"

--- a/oreum_core/curate/data_load.py
+++ b/oreum_core/curate/data_load.py
@@ -35,6 +35,7 @@ class SimpleStringIO:
         if len(relpath) == 0:
             relpath = self.relpath
         fqn = os.path.join(*relpath, f'{fn}.{self.kind}')
+        assert os.path.exists(fqn)
         with open(fqn, 'r') as f:
             s = f.read().rstrip('\n')
             f.close()
@@ -46,6 +47,7 @@ class SimpleStringIO:
         if len(relpath) == 0:
             relpath = self.relpath
         fqn = os.path.join(*relpath, f'{fn}.{self.kind}')
+        assert os.path.exists(fqn)
         if self.kind == 'json':
             s = json.dumps(s)
         with open(fqn, 'w') as f:
@@ -56,6 +58,7 @@ class SimpleStringIO:
 
 def copy_csv2md(fqn: str) -> str:
     """Convenience to copy csv 'path/x.csv' to markdown 'path/x.md'"""
+    assert os.path.exists(fqn)
     r = subprocess.run(['csv2md', f'{fqn}'], capture_output=True)
     with open(f'{fqn[:-3] + "md"}', 'wb') as f:
         f.write(r.stdout)

--- a/oreum_core/model/__init__.py
+++ b/oreum_core/model/__init__.py
@@ -30,10 +30,10 @@ from oreum_core.model.distributions import (
     boundzero_theano,
 )
 from oreum_core.model.plot import (
-    facetplot_azid_dist,
     facetplot_df_dist,
+    facetplot_idata_dist,
     plot_dist_fns_over_x,
     plot_dist_fns_over_x_manual_only,
     plot_ppc_loopit,
 )
-from oreum_core.model.utils import read_azid, save_graph, write_azid
+from oreum_core.model.utils import read_idata, save_graph, write_idata

--- a/oreum_core/model/base.py
+++ b/oreum_core/model/base.py
@@ -157,7 +157,7 @@ class BasePYMC3Model:
         use self.sample_posterior_predictive_kws or passed kwargs
         Note defaults aimed toward PPC in production
             + Use pm.fast_sample_posterior_predictive()
-            + Don't store ppc on model object and just return a new azid
+            + Don't store ppc on model object and just return a new idata
         """
         random_seed = kwargs.pop('random_seed', self.sample_kws['random_seed'])
         fast = kwargs.pop('fast', self.sample_posterior_predictive_kws['fast'])

--- a/oreum_core/model/base.py
+++ b/oreum_core/model/base.py
@@ -214,16 +214,3 @@ class BasePYMC3Model:
         else:
             self._idata = self._create_idata(**kwargs)
         return None
-
-
-# TODO save and check cache e.g
-# https://discourse.pymc.io/t/jupyter-idiom-for-cached-results/6782
-# idata_file = "myfilename.nc"
-# if os.path.exists(idata_file):
-# idata = az.from_netcdf(idata_file)
-# else:
-# idata = <some expensive computation>
-# if not os.path.exists(idata_file):
-# az.to_netcdf(idata, idata_file)
-# also:
-# _inference_data.posterior.attrs["model_version"] = self.version

--- a/oreum_core/model/describe.py
+++ b/oreum_core/model/describe.py
@@ -29,13 +29,13 @@ def model_desc(fml):
     return f'patsy linear model desc:\n{r}\n'
 
 
-def extract_yobs_yhat(azid, obs='y', pred='yhat'):
-    """Convenience: extract y_obs, y_hat from azid
+def extract_yobs_yhat(idata, obs='y', pred='yhat'):
+    """Convenience: extract y_obs, y_hat from idata
     get yhat in the shape (nsamples, nobs)
     """
-    nsamp = np.product(azid.posterior_predictive[pred].shape[:-1])
-    yobs = azid.constant_data[obs].values  # (nobs,)
-    yhat = azid.posterior_predictive[pred].values.reshape(nsamp, -1)  # (nsamp, nobs)
+    nsamp = np.product(idata.posterior_predictive[pred].shape[:-1])
+    yobs = idata.constant_data[obs].values  # (nobs,)
+    yhat = idata.posterior_predictive[pred].values.reshape(nsamp, -1)  # (nsamp, nobs)
     return yobs, yhat
 
 

--- a/oreum_core/model/plot.py
+++ b/oreum_core/model/plot.py
@@ -9,7 +9,7 @@ from matplotlib import figure, gridspec
 
 __all__ = [
     'plot_ppc_loopit',
-    'facetplot_azid_dist',
+    'facetplot_idata_dist',
     'facetplot_df_dist',
     'plot_dist_fns_over_x',
     'plot_dist_fns_over_x_manual_only',
@@ -67,7 +67,7 @@ def plot_ppc_loopit(
     return f
 
 
-def facetplot_azid_dist(
+def facetplot_idata_dist(
     idata: az.data.inference_data.InferenceData,
     rvs: list,
     group: str = 'posterior',
@@ -75,7 +75,7 @@ def facetplot_azid_dist(
     rvs_hack: int = 0,
     **kwargs,
 ) -> figure.Figure:
-    """Control facet positioning of Arviz Krushke style plots, data in azid
+    """Control facet positioning of Arviz Krushke style plots, data in idata
     Pass-through kwargs to az.plot_posterior, e.g. ref_val
     """
     # TODO unpack the compressed rvs from the idata

--- a/oreum_core/model/utils.py
+++ b/oreum_core/model/utils.py
@@ -7,14 +7,14 @@ import arviz as az
 import pymc3 as pm
 
 
-def read_azid(dir_traces: list = [], fn: str = 'azid'):
+def read_idata(dir_traces: list = [], fn: str = 'idata'):
     """Convenience: read arviz.InferenceData object from file"""
     # with az.rc_context(rc={'data.load': 'eager'}):   # alternative: 'lazy'
-    azid = az.from_netcdf(os.path.join(*dir_traces, f'{fn}.netcdf'))
-    return azid
+    idata = az.from_netcdf(os.path.join(*dir_traces, f'{fn}.netcdf'))
+    return idata
 
 
-def write_azid(mdl, dir_traces: list = []):
+def write_idata(mdl, dir_traces: list = []) -> str:
     """Accept a BasePYMC3Model object mdl, and write the
     mdl.idata (an arviz.InferenceData object) to file using mdl.name
     """


### PR DESCRIPTION
+ [x] Overhauled `BasePYMC3Model` to save traces to `idata` only
+ [x] Overhauled `_create_idata` accordingly to allow creation from prior, trace or posterior idata with logical dependencies
+ [x] Overhauled `update_idata` accordingly to allow attaching an externally loaded idata object (model reinstantiation)
+ [x] Renamed all relevant functions to use `idata` rather than `azid`